### PR TITLE
Reordered release actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
   - >
     ./gradlew build bintrayUpload --scan -PbintrayDryRun
     && if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ];
-      then ./gradlew githubRelease bintrayUpload --scan; fi
+      then ./gradlew bintrayUpload githubRelease --scan; fi


### PR DESCRIPTION
Based the experience from Mockito project let's try the approach to perform "bintrayUpload" *before* tagging the release in GitHub.

Originally we thought that tagging *before* artifact publishing is a good idea. Bad tag is easier to revert than reverting binary artifacts publish. In fact, we cannot unpublish artifacts from some repositories, such as  Maven Central. In practice though, tagging almost never fails. Therefore, let's run the task that *may* fail before tagging. This way, in case of a failure, there is less manual fixing (removing tags/release notes from GH) and less confusion to our end users (no more releases on GH that don't have any artifacts).