### PR TITLE
Apply new Shipkit Auto Version property

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -4,7 +4,7 @@ apply plugin: "org.shipkit.shipkit-changelog"
 apply plugin: "org.shipkit.shipkit-gh-release"
 
 tasks.named("generateChangelog") {
-    previousRevision = "v" + project.ext.'shipkit-auto-version.previous-version'
+    previousRevision = project.ext.'shipkit-auto-version.previous-tag'
     readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
     repository = "shipkit/shipkit-demo"
 }


### PR DESCRIPTION
Shipkit Auto Version plugin exposes new 'ext' property for getting previous revision: project.ext.'shipkit-auto-version.previous-tag'. This property is easier to use than earlier used 'shipkit-auto-version.previous-version'; using it makes also code clearer.
Earlier to get previous revision (e.g. for generating chengelog with Shipkit Changelog plugin) concatenation and possible conditional had to be used. Now it requires just to refer to 'shipkit-auto-version.previous-tag' alone.