### PR TITLE
Aplly renamed plugin package

### DIFF
--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,7 +1,7 @@
 //Plugin jars are added to the buildscript classpath in the root build.gradle file
 apply plugin: "org.shipkit.shipkit-auto-version"
 apply plugin: "org.shipkit.shipkit-changelog"
-apply plugin: "org.shipkit.shipkit-gh-release"
+apply plugin: "org.shipkit.shipkit-github-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'


### PR DESCRIPTION
Due to recent Github related naming convention applied in Shipkit Changelog plugin, the referenced 'org.shipkit.shipkit-gh-release' package should be changed for 'org.shipkit.shipkit-github-release'.