### PR TITLE
Apply new Shipkit Changelog properties and bump Shipkit plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "org.shipkit:shipkit-auto-version:0.+"
-        classpath "org.shipkit:shipkit-changelog:0.+"
+        classpath "org.shipkit:shipkit-auto-version:1.+"
+        classpath "org.shipkit:shipkit-changelog:1.+"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+"
     }
 }

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -5,7 +5,7 @@ apply plugin: "org.shipkit.shipkit-github-release"
 
 tasks.named("generateChangelog") {
     previousRevision = project.ext.'shipkit-auto-version.previous-tag'
-    readOnlyToken = "a0a4c0f41c200f7c653323014d6a72a127764e17"
+    githubToken = System.getenv("GH_WRITE_TOKEN")
     repository = "shipkit/shipkit-demo"
 }
 
@@ -13,7 +13,8 @@ tasks.named("githubRelease") {
     dependsOn tasks.named("generateChangelog")
     repository = "shipkit/shipkit-demo"
     changelog = tasks.named("generateChangelog").get().outputFile
-    writeToken = System.getenv("GH_WRITE_TOKEN")
+    githubToken = System.getenv("GH_WRITE_TOKEN")
+    newTagRevision = System.getenv("TRAVIS_COMMIT")
 }
 
 allprojects { p ->


### PR DESCRIPTION
Two new properties has been recently added to Shipkit Changelog plugin:

1. `newTagRevision` eliminates problem with wrong tagging, when release is tagged with revision reference that the release does not come from, but is the latest one on master branch. To get the SHA of the commit that triggered the workflow 'TRAVIS_COMMIT' env var is used.
2. `githubToken` is used both to fetch and post via GH API, instead of _'readOnlyToken'_ and _'writeToken'_. As the token assigned to _'githubToken'_ should have write access to the repository, it should be supplied by the env variable to keep things safe. Using this property simplifies configuration. Deprecated properties should be replaced with the new one.

Also new versions of Shipkit Auto Version and Shipkit Changelog plugins have been recently released. The plugins' versions in the project can now be bumped.